### PR TITLE
[FEAT] Redis 기반 실시간 알림 시스템 환경 설정 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 	// Swagger 문서화
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+	// Redis 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
 	// 데이터베이스
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,20 @@ services:
     ports:
       - "3306:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql_data:/var/lib/mysql
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.0-alpine
+    container_name: moneybuddy-redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes --requirepass ""
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+volumes:
+  mysql_data:
+  redis_data:

--- a/src/main/java/moneybuddy/global/config/RedisConfig.java
+++ b/src/main/java/moneybuddy/global/config/RedisConfig.java
@@ -1,0 +1,52 @@
+package moneybuddy.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+  private final RedisProperties redisProperties;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(
+        redisProperties.getHost(),
+        redisProperties.getPort()
+    );
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer() {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(redisConnectionFactory());
+    return container;
+  }
+}

--- a/src/main/java/moneybuddy/global/config/RedisConnectionTest.java
+++ b/src/main/java/moneybuddy/global/config/RedisConnectionTest.java
@@ -1,0 +1,34 @@
+package moneybuddy.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisConnectionTest implements CommandLineRunner {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Override
+  public void run(String... args) throws Exception {
+    try {
+      redisTemplate.opsForValue().set("test:connection", "success");
+      String result = (String) redisTemplate.opsForValue().get("test:connection");
+
+      if ("success".equals(result)) {
+        log.info("Redis 연결 성공.");
+      } else {
+        log.error("Redis 연결 실패: 값 불일치 (expected: success, actual: {})", result);
+      }
+
+      redisTemplate.delete("test:connection");
+      log.debug("Redis 연결 테스트 키 정리 완료");
+    } catch (Exception e) {
+      log.error("Redis 연결 실패 - 에러 상세: {}", e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
## 📦 작업 파일 목록

### 1. `build.gradle` 수정
```gradle
dependencies {
    // 기존 의존성들...
    
    // Redis 의존성 추가
    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
    implementation 'org.springframework.session:spring-session-data-redis'
    
    // 기존 의존성들...
}
```

### 2. `docker-compose.yml` 수정
```yaml
version: '3.8'

services:
  mysql:
    image: mysql:8.0
    container_name: moneybuddy-mysql
    environment:
      MYSQL_ROOT_PASSWORD: 1234
      MYSQL_DATABASE: moneybuddy
    ports:
      - "3306:3306"
    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci

  redis:
    image: redis:7.0-alpine
    container_name: moneybuddy-redis
    ports:
      - "6379:6379"
    command: redis-server --appendonly yes
    volumes:
      - redis_data:/data

volumes:
  redis_data:
```

### 3. `src/main/java/moneybuddy/config/RedisConfig.java` 생성
```java
package moneybuddy.config;

import com.fasterxml.jackson.databind.ObjectMapper;
import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
import lombok.RequiredArgsConstructor;
import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.data.redis.connection.RedisConnectionFactory;
import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
import org.springframework.data.redis.core.RedisTemplate;
import org.springframework.data.redis.listener.RedisMessageListenerContainer;
import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
import org.springframework.data.redis.serializer.StringRedisSerializer;

@Configuration
@RequiredArgsConstructor
public class RedisConfig {

  private final RedisProperties redisProperties;

  @Bean
  public RedisConnectionFactory redisConnectionFactory() {
    return new LettuceConnectionFactory(
        redisProperties.getHost(),
        redisProperties.getPort()
    );
  }

  @Bean
  public RedisTemplate<String, Object> redisTemplate() {
    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
    redisTemplate.setConnectionFactory(redisConnectionFactory());

    // ObjectMapper 설정
    ObjectMapper objectMapper = new ObjectMapper();
    objectMapper.registerModule(new JavaTimeModule());

    // Key는 String, Value는 JSON으로 직렬화
    redisTemplate.setKeySerializer(new StringRedisSerializer());
    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));

    return redisTemplate;
  }

  @Bean
  public RedisMessageListenerContainer redisMessageListenerContainer() {
    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
    container.setConnectionFactory(redisConnectionFactory());
    return container;
  }
}
```

### 4. `application.yml` 수정
```yaml
spring:
  application:
    name: moneybuddy

  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: jdbc:mysql://localhost:3306/moneybuddy?useSSL=false&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
    username: root
    password: 1234

  # Redis 설정 추가
  data:
    redis:
      host: localhost
      port: 6379
      timeout: 2000ms
      lettuce:
        pool:
          max-active: 8
          max-idle: 8
          min-idle: 0

  jpa:
    hibernate:
      ddl-auto: create-drop
    show-sql: true
    properties:
      hibernate:
        format_sql: true
        dialect: org.hibernate.dialect.MySQLDialect

logging:
  level:
    moneybuddy: DEBUG
    org.springframework.security: DEBUG
    org.hibernate.SQL: DEBUG

server:
  port: 8080
  error:
    include-message: always
    include-binding-errors: always

jwt:
  secret: moneybuddy-secret-key-for-backend-development-dohyun-sumin-zerobase-project
  expiration: 86400000

# 알림 설정
notification:
  redis:
    notification-expire-hours: 24
    unread-count-expire-hours: 1
```

### 5. Redis 연결 테스트용 간단한 Service 생성
`src/main/java/moneybuddy/config/RedisConnectionTest.java`
```java
package moneybuddy.config;

import lombok.RequiredArgsConstructor;
import lombok.extern.slf4j.Slf4j;
import org.springframework.boot.CommandLineRunner;
import org.springframework.data.redis.core.RedisTemplate;
import org.springframework.stereotype.Component;

@Component
@RequiredArgsConstructor
@Slf4j
public class RedisConnectionTest implements CommandLineRunner {

  private final RedisTemplate<String, Object> redisTemplate;

  @Override
  public void run(String... args) throws Exception {
    try {
      // Redis 연결 테스트
      redisTemplate.opsForValue().set("test:connection", "success");
      String result = (String) redisTemplate.opsForValue().get("test:connection");
      
      if ("success".equals(result)) {
        log.info("✅ Redis 연결 성공!");
      } else {
        log.error("❌ Redis 연결 실패: 값 불일치");
      }
      
      // 테스트 키 삭제
      redisTemplate.delete("test:connection");
      
    } catch (Exception e) {
      log.error("❌ Redis 연결 실패: {}", e.getMessage());
    }
  }
}
```

## 🧪 손테스트 가이드

### 1. 환경 설정 테스트
```bash
# 1. Redis 컨테이너 실행
docker-compose up -d redis

# 2. Redis 컨테이너 상태 확인
docker ps | grep redis
# 결과: moneybuddy-redis 컨테이너가 실행 중이어야 함

# 3. Redis 직접 접속 테스트
docker exec -it moneybuddy-redis redis-cli ping
# 결과: PONG이 나와야 함
```

### 2. 애플리케이션 테스트
```bash
# 1. 애플리케이션 실행
./gradlew bootRun

# 2. 로그에서 Redis 연결 성공 메시지 확인
# "✅ Redis 연결 성공!" 메시지가 출력되어야 함

# 3. 애플리케이션이 정상적으로 실행되는지 확인
# 8080 포트에서 서버가 실행되어야 함
```

### 3. Redis 데이터 확인
```bash
# Redis CLI 접속
docker exec -it moneybuddy-redis redis-cli

# 키 목록 확인 (비어있어야 함)
127.0.0.1:6379> keys *
(empty array)

# 연결 테스트
127.0.0.1:6379> ping
PONG

# 종료
127.0.0.1:6379> exit
```

### 손테스트 상세 내용
1. `docker-compose up -d redis` 실행 ✅
2. `docker ps | grep redis` 컨테이너 확인 ✅
3. `docker exec -it moneybuddy-redis redis-cli ping` 응답 확인 ✅
4. `./gradlew bootRun` 정상 실행 ✅
5. 로그에서 "✅ Redis 연결 성공!" 메시지 확인 ✅

## 📋 다음 단계
- [ ] 알림 엔티티 및 Repository 구현
- [ ] 기본 알림 CRUD API 구현
- [ ] WebSocket 실시간 통신 구현

## 🔗 관련 이슈
실시간 알림 시스템 구축 작업의 첫 번째 단계입니다.